### PR TITLE
Adding 404 http-code to Missing controller

### DIFF
--- a/server/controllers/base.js
+++ b/server/controllers/base.js
@@ -25,7 +25,7 @@ module.exports = {
         handler: function(request, reply){
             reply.view('404', {
                 title: 'You found a missing page, but won the 404 error!'
-            });
+            }).code(404);
         },
         app: {
             name: '404'


### PR DESCRIPTION
Without this fix, all missing-pages response 200 http-code.
This is bad for Seo, ...

Greetings.
