### PR TITLE
Add lout plugin to hapi-ninja

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "swig": "~1.3.2",
     "hapi-named-routes": "~0.2.0",
     "hapi-assets": "~0.2.0",
-    "hapi-cache-buster": "~0.2.0"
+    "hapi-cache-buster": "~0.2.0",
+    "joi": "^4.6.1",
+    "lout": "^5.0.0"
   },
   "devDependencies": {
     "gulp": "~3.8.0",

--- a/server/config/plugins.js
+++ b/server/config/plugins.js
@@ -23,6 +23,9 @@ module.exports = function(server) {
         },
         {
             plugin: require("hapi-cache-buster")
+        },
+        {
+            plugin: require("lout")
         }
     ], function(err) {
         if (err) throw err;


### PR DESCRIPTION
[Lout](https://github.com/spumko/lout) is an easy way to check configured routes by heading to /docs on a new site.  Didn't know if there was a way to add this plugin to the development environment only, but thought I would at least share the suggestion.
