### PR TITLE
Added name parameter to pack.register method in plugins.js

### DIFF
--- a/server/config/plugins.js
+++ b/server/config/plugins.js
@@ -13,17 +13,21 @@ var assetOptions = require(settings.rootPath + '/assets');
 
 server.pack.register([
     {
+        name: "good",
         plugin: require("good"),
         options: goodOptions
     },
     {
+        name: "hapi-assets",
         plugin: require("hapi-assets"),
         options: assetOptions
     },
     {
+        name: "hapi-named-routes",
         plugin: require("hapi-named-routes")
     },
     {
+        name: "hapi-cache-buster",
         plugin: require("hapi-cache-buster")
     }
 ], function(err) {


### PR DESCRIPTION
Added a name parameter to the pack.register method because it is required.
